### PR TITLE
Christian/test

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,0 +1,4 @@
+{
+    hostName = "_template_";
+    userName = "_template_";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -30,11 +30,9 @@
   ##############################################################################
   outputs = { self, nixpkgs, nix-darwin, home-manager, nix-homebrew, ... }@inputs:
     let
-      # Host & user data – adjust if you rename the machine or account
-      # hostName = <hostname>;
-      # userName = <username>;
-      hostName = "insignia";
-      userName = "heyglassy";
+      # Host & user data – adjust in `configuration.nix`
+      inherit (import ./configuration.nix) hostName userName;
+
       system = "aarch64-darwin"; # or "x86_64-darwin" for Intel Macs
 
       # Import the desired nixpkgs for this system

--- a/ghostty_config.txt
+++ b/ghostty_config.txt
@@ -1,10 +1,11 @@
+title = _template_
+
 font-family = Berkeley Mono
 confirm-close-surface = false
 copy-on-select = clipboard
 macos-titlebar-style = tabs
 window-width = 100000
 window-height = 100000
-title = insignia
 theme = dark:Ghostty Default StyleDark,light:catppuccin-latte
 
 mouse-hide-while-typing = true

--- a/justfile
+++ b/justfile
@@ -3,8 +3,13 @@ host := `scutil --get ComputerName 2>/dev/null \
          || scutil --get HostName 2>/dev/null \
          || hostname`
 
+user := `id -un`
+
 update :
     nix flake update
+
+ghostty-title:
+    sed -i '' -E "s/^title[[:space:]]*=[[:space:]]*.*/title = {{host}}/" /Users/carnegie/nix/ghostty_config.txt
 
 activate :
     darwin-rebuild activate
@@ -15,7 +20,10 @@ doctor :
 shells:
     sudo sh -c 'echo "/run/current-system/sw/bin/bash" >> /etc/shells'
 
-switch:
+config: ghostty-title
+    printf '%s\n' '{' "    hostName = \"{{host}}\";" "    userName = \"{{user}}\";" '}' > configuration.nix
+
+switch: config
     darwin-rebuild switch --flake .#{{host}}
     bun ./scripts/post_switch.ts
     just kbd

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ host := `scutil --get ComputerName 2>/dev/null \
          || scutil --get HostName 2>/dev/null \
          || hostname`
 
-user := `id -un`
+user := `if [ -n "$SUDO_USER" ]; then printf "%s" "$SUDO_USER"; else id -un; fi`
 
 update :
     nix flake update


### PR DESCRIPTION
<!-- mesa-description-start -->
## TL;DR
Automated NixOS/Darwin system configuration and rebuilds, centralizing host/user settings and enabling dynamic terminal titles.

## Why we made these changes
To streamline NixOS/Darwin setup by automating `configuration.nix` generation, prevent hardcoding sensitive host/user details, and dynamically set terminal titles for better context.

## What changed?
- **`configuration.nix`**: Now serves as the central system config, implicitly designed to integrate dynamic host/user details.
- **`flake.nix`**: Modified to inherit `hostName` and `userName` from `configuration.nix`, promoting centralized configuration.
- **`ghostty_config.txt`**: Updated `title` to `_template_` and added a blank line, likely preparing for dynamic title injection.
- **`justfile`**: Enhanced with a new `config` recipe to dynamically generate `configuration.nix` based on current user/hostname. `config` is now a prerequisite for `switch`. A new `ghostty-title` recipe was added to dynamically set the terminal title.

## Validation
- [ ] Running `just switch` successfully rebuilds the system with the dynamically generated `configuration.nix`.
- [ ] The generated `configuration.nix` correctly reflects the current hostname and username.
- [ ] The Ghostty terminal title is set dynamically as expected when launched via the new `just` recipe.
- [ ] No regressions introduced in existing system configurations or services.

<sup>_Description generated by Mesa. [Update settings](https://app.mesa.dev/heyglassy/settings/pull-requests)_</sup>
<!-- mesa-description-end -->